### PR TITLE
Feature / Emoji Colouroji

### DIFF
--- a/src/library/withWrapper.jsx
+++ b/src/library/withWrapper.jsx
@@ -3,13 +3,24 @@ import React from 'react'
 const fromPercentage = percentage => parseInt(percentage, 10) / 100
 
 const withWrapper = Component => {
-  const wrapper = (x = 50, y = 50, scale = 100, rotate = 0) => (
+  const wrapper = (id, x = 50, y = 50, scale = 100, rotate = 0, colour) => (
     <g transform={`translate(${x}, ${y})`} style={{ transformOrigin: 'center' }}>
-      <svg x="-50" y="-50">
+      {colour && (
+        <defs>
+          <filter id={`${id}/colour-shift`} x="0" y="0" width="100%" height="100%">
+            <feFlood floodColor={colour} result="flood" />
+            <feComposite in="flood" in2="SourceAlpha" operator="in" result="flood-alpha" />
+            <feBlend mode="hue" in="flood-alpha" in2="SourceGraphic" />
+          </filter>
+        </defs>
+      )}
+
+      <svg x="-50" y="-50" id={id}>
         <g
           style={{
             transform: `rotate(${rotate}deg) scale(${fromPercentage(scale)})`,
             transformOrigin: 'center',
+            filter: colour ? `url(#${id}/colour-shift)` : '',
           }}
         >
           <Component />

--- a/src/utils/evaluate.js
+++ b/src/utils/evaluate.js
@@ -24,13 +24,18 @@ const evaluate = text => {
         return
       }
 
+      const commandName = groups[1]
+      const args = groups[2]
+        .split(',')
+        .map(arg => arg.trim())
+        .filter(_ => _)
+
+      const id = `${lineNumber}:${commandName}`
+
       commands.push({
         lineNumber,
-        command: groups[1],
-        args: groups[2]
-          .split(',')
-          .map(arg => arg.trim())
-          .filter(_ => _),
+        command: commandName,
+        args: [id, ...args],
       })
     })
 


### PR DESCRIPTION
This PR adds colour shifting to the withWrapper hoc, allowing full svgs to be recoloured with a tint layer rather than directly setting fill/stroke. This means we can have colour on all the emojis!! It might be a little too washed out, I'm not sure? I think we need to test this one with people

🚨🚨🚨 this only works in chrome i think because feBlend doesn't technically support the hue mode, as it's a css blend mode and the spec isn't equivalent with those yet 🚨🚨🚨